### PR TITLE
Fix nvvm library path on Windows.

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -62,8 +62,8 @@ nvvmLibraryPath platform@(Platform arch os) = nvvmPath platform </> libpath
   where
     libpath =
       case (os, arch) of
-        (Windows, I386)   -> "Win32"
-        (Windows, X86_64) -> "x64"
+        (Windows, I386)   -> "lib" </> "Win32"
+        (Windows, X86_64) -> "lib" </> "x64"
         (OSX,     _)      -> "lib"    -- MacOS does not distinguish 32- vs. 64-bit paths
         (_,       X86_64) -> "lib64"  -- treat all others similarly
         _                 -> "lib"


### PR DESCRIPTION
On my Windows 10 machine with CUDA 8,  `nvvm.lib` is in `<nvvm-path>\lib\x64`, rather than `<nvvm-path>\x64`. I installed CUDA with the default settings, so I'd be surprised if this is a peculiarity of my machine. `nvvm.lib` isn't found on Windows without this change.