### PR TITLE
Pre-checks RPATH to avoid duplication

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,7 +1,9 @@
-{-# LANGUAGE CPP               #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE QuasiQuotes       #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE CPP                  #-}
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE QuasiQuotes          #-}
+{-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE OverloadedStrings    #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
 
 -- This macro is only available when compiling with GHC-8
 #ifndef MIN_VERSION_Cabal
@@ -36,13 +38,18 @@ import Foreign.CUDA.Path
 import Control.Applicative
 import Control.Exception
 import Control.Monad
+import Data.List
 import System.Directory
 import System.FilePath
 import Text.Printf
+import Data.Char
 import Prelude
 
 import Language.Haskell.TH
 
+import qualified Data.Text as T
+
+default (String)
 
 -- Configuration
 -- -------------
@@ -180,17 +187,47 @@ main = defaultMainWithHooks customHooks
 -- what Apple's system libraries do for example.
 --
 updateLibraryRPATHs :: Verbosity -> Platform -> FilePath -> [FilePath] -> IO ()
-updateLibraryRPATHs verbosity (Platform _ os) sharedLib extraLibDirs' =
+updateLibraryRPATHs verbosity pf@(Platform _ os) sharedLib extraLibDirs' =
   when (os == OSX) $ do
     exists <- doesFileExist sharedLib
     unless exists $ die' verbosity $ printf "Unexpected failure: library does not exist: %s" sharedLib
     --
+    rpaths <- getLibraryRPATHs verbosity pf sharedLib
     mint   <- findProgram verbosity "install_name_tool"
     case mint of
       Nothing                -> notice verbosity $ "Could not locate 'install_name_tool' in order to update LC_RPATH entries. This is likely to cause problems later on."
       Just install_name_tool ->
-        forM_ extraLibDirs' $ \libDir ->
+        forM_ (extraLibDirs' \\ rpaths) $ \libDir ->
           runProgramInvocation verbosity $ simpleProgramInvocation install_name_tool ["-add_rpath", libDir, sharedLib]
+
+parseRPATHs :: String -> [FilePath]
+parseRPATHs = loop [] . T.lines . T.pack
+  where
+    loop acc xs =
+      case break (T.isPrefixOf "Load command") xs of
+        (_, []) -> acc
+        (_, _ : cmd : rest)
+          | T.stripPrefix "cmd " (T.stripStart cmd) == Just "LC_RPATH"
+            -> let l:ls = dropWhile (not . T.isPrefixOf "path " . T.stripStart) rest
+                   Just (path, _) = T.breakOnEnd " (offset" <$> T.stripPrefix "path " (T.stripStart l)
+               in loop (T.unpack (T.dropEnd 8 path) : acc) ls
+          | otherwise -> loop acc rest
+    
+
+getLibraryRPATHs :: Verbosity -> Platform -> FilePath -> IO [FilePath]
+getLibraryRPATHs verbosity (Platform _ os) sharedLib =
+  if os /= OSX
+  then return []
+  else do
+    exists <- doesFileExist sharedLib
+    unless exists $ die' verbosity $ printf "Unexpected failure: library does not exist: %s" sharedLib
+    mint   <- findProgram verbosity "otool"
+    case mint of
+      Nothing    -> do
+        notice verbosity $ "Could not locate 'otool' in order to get LC_RPATH entries. This is likely to cause problems later on."
+        return []
+      Just otool ->
+        parseRPATHs <$> getProgramInvocationOutput verbosity (simpleProgramInvocation otool ["-l", sharedLib])
 
 
 -- Reads user-provided `nvvm.buildinfo` if present, otherwise loads `nvvm.buildinfo.generated`
@@ -432,7 +469,7 @@ getCppOptions :: BuildInfo -> LocalBuildInfo -> [String]
 getCppOptions bi lbi
     = hcDefines (compiler lbi)
    ++ ["-I" ++ dir | dir <- includeDirs bi]
-   ++ [opt | opt@('-':c:_) <- ccOptions bi, c `elem` "DIU"]
+   ++ [opt | opt@('-':c:_) <- ccOptions bi, c `elem` ("DIU" :: String)]
 
 hcDefines :: Compiler -> [String]
 hcDefines comp =

--- a/nvvm.cabal
+++ b/nvvm.cabal
@@ -45,6 +45,7 @@ custom-setup
     , cuda              >= 0.8
     , directory         >= 1.0
     , filepath          >= 1.0
+    , text
     , template-haskell
 
 library


### PR DESCRIPTION
On macOS 10.13.6 with GHC 8.4.3, `nvvm` fails to compile when it is compiled as a dependency for other package:

```
    [5 of 5] Compiling Foreign.NVVM     ( Foreign/NVVM.hs, .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/Foreign/NVVM.p_o )
    clang: warning: argument unused during compilation: '-nopie' [-Wunused-command-line-argument]
    clang: warning: argument unused during compilation: '-nopie' [-Wunused-command-line-argument]
    ignoring (possibly broken) abi-depends field for packages
    error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/install_name_tool: for: .stack-work/dist/x86_64-osx/Cabal-2.2.0.1/build/libHSnvvm-0.8.0.3-DgQ0osQbuUpFhmpbs2hbRg-ghc8.4.3.dylib (for architecture x86_64) option "-add_rpath /usr/local/Cellar/llvm-6.0/6.0.0/lib" would duplicate path, file already has LC_RPATH for: /usr/local/Cellar/llvm-6.0/6.0.0/lib
```

Note that compilation succeeds when `nvvm` is compiled alone.

To fix this, I added the ad-hoc check that uses `otool` to extract `LC_RPATH`s first and excludes existing ones.