### PR TITLE
Support Cabal v3 in Setup.hs

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -282,7 +282,11 @@ libraryBuildInfo profile platform@(Platform arch os) ghcVersion = do
     , ldOptions      = ldOptions'
     , extraLibs      = extraLibs'
     , extraLibDirs   = extraLibDirs'
+#if MIN_VERSION_Cabal(3,0,0)
+    , options        = PerCompilerFlavor (if os /= Windows then ghcOptions else []) []
+#else
     , options        = [(GHC, ghcOptions) | os /= Windows]
+#endif
     , customFieldsBI = [c2hsExtraOptions]
     }
 


### PR DESCRIPTION
The `options` field of the `BuildInfo` struct changed its type starting with Cabal 3.0.0.0; this means that `Setup.hs` did not run anymore with a newer Cabal version.

For reference, see https://github.com/tmcdonell/cuda/pull/59.