### PR TITLE
Fix Setup.hs configure

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -83,7 +83,6 @@ main :: IO ()
 main = defaultMainWithHooks customHooks
   where
     readHook get_verbosity args flags = do
-        noExtraFlags args
         getHookedBuildInfo (fromFlag (get_verbosity flags))
 
     preprocessors = hookedPreProcessors simpleUserHooks
@@ -124,7 +123,6 @@ main = defaultMainWithHooks customHooks
           currentPlatform = hostPlatform lbi
           compilerId_     = compilerId (compiler lbi)
       --
-      noExtraFlags args
       generateAndStoreBuildInfo verbosity profile currentPlatform compilerId_ generatedBuildInfoFilePath
       validateLinker verbosity currentPlatform $ withPrograms lbi
       --


### PR DESCRIPTION
If `Setup.hs configure` is called directly with a component name as an argument, `noExtraFlags` will complain with something like `unrecognised flag: lib:nvvm`.